### PR TITLE
Initial Setup and Implicit this Check 

### DIFF
--- a/clang-tools-extra/clang-tidy/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/CMakeLists.txt
@@ -50,6 +50,7 @@ add_subdirectory(darwin)
 add_subdirectory(fuchsia)
 add_subdirectory(google)
 add_subdirectory(hicpp)
+add_subdirectory(kokkos)
 add_subdirectory(linuxkernel)
 add_subdirectory(llvm)
 add_subdirectory(llvmlibc)
@@ -75,6 +76,7 @@ set(ALL_CLANG_TIDY_CHECKS
   clangTidyFuchsiaModule
   clangTidyGoogleModule
   clangTidyHICPPModule
+  clangTidyKokkosModule
   clangTidyLinuxKernelModule
   clangTidyLLVMModule
   clangTidyLLVMLibcModule

--- a/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
@@ -1,5 +1,9 @@
 //===- ClangTidyForceLinker.h - clang-tidy --------------------------------===//
 //
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -64,6 +68,11 @@ static int LLVM_ATTRIBUTE_UNUSED GoogleModuleAnchorDestination =
 extern volatile int HICPPModuleAnchorSource;
 static int LLVM_ATTRIBUTE_UNUSED HICPPModuleAnchorDestination =
     HICPPModuleAnchorSource;
+
+// This anchor is used to force the linker to link the KokkosModule.
+extern volatile int KokkosModuleAnchorSource;
+static int LLVM_ATTRIBUTE_UNUSED KokkosModuleAnchorDestination =
+    KokkosModuleAnchorSource;
 
 // This anchor is used to force the linker to link the LinuxKernelModule.
 extern volatile int LinuxKernelModuleAnchorSource;

--- a/clang-tools-extra/clang-tidy/add_new_check.py
+++ b/clang-tools-extra/clang-tidy/add_new_check.py
@@ -61,6 +61,10 @@ def write_header(module_path, module, namespace, check_name, check_name_camel):
     f.write('*- C++ -*-===//')
     f.write("""
 //
+// Copyright 2020 National Technology & Engineering Solutions of Sandia,
+// LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/clang-tools-extra/clang-tidy/kokkos/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/kokkos/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS support)
 
 add_clang_library(clangTidyKokkosModule
   ImplicitThisCaptureCheck.cpp
+  KokkosMatchers.cpp
   KokkosTidyModule.cpp
 
   LINK_LIBS

--- a/clang-tools-extra/clang-tidy/kokkos/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/kokkos/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(LLVM_LINK_COMPONENTS support)
+
+add_clang_library(clangTidyKokkosModule
+  ImplicitThisCaptureCheck.cpp
+  KokkosTidyModule.cpp
+
+  LINK_LIBS
+  clangAnalysis
+  clangAST
+  clangASTMatchers
+  clangBasic
+  clangLex
+  clangTidy
+  clangTidyUtils
+  )

--- a/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.cpp
@@ -1,0 +1,94 @@
+//===--- ImplicitThisCaptureCheck.cpp - clang-tidy ------------------------===//
+//
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImplicitThisCaptureCheck.h"
+#include "KokkosMatchers.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "llvm/ADT/Optional.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace kokkos {
+
+namespace {
+llvm::Optional<SourceLocation> capturesThis(CXXRecordDecl const *CRD) {
+  if (!CRD->isLambda()) {
+    return llvm::None;
+  }
+
+  for (auto const &Capture : CRD->captures()) {
+    if (Capture.capturesThis()) {
+      return llvm::Optional<SourceLocation>(Capture.getLocation());
+    }
+  }
+
+  return llvm::None;
+}
+
+} // namespace
+
+ImplicitThisCaptureCheck::ImplicitThisCaptureCheck(
+    StringRef Name, ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context) {
+  CheckIfExplicitHost = std::stoi(Options.get("CheckIfExplicitHost", "0"));
+  HostTypeDefRegex =
+      Options.get("HostTypeDefRegex", "Kokkos::DefaultHostExecutionSpace");
+}
+
+void ImplicitThisCaptureCheck::storeOptions(
+    ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "CheckIfExplicitHost",
+                std::to_string(CheckIfExplicitHost));
+  Options.store(Opts, "HostTypeDefRegex", HostTypeDefRegex);
+}
+
+void ImplicitThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
+  auto isAllowedPolicy = expr(hasType(
+      cxxRecordDecl(matchesName("::Impl::ThreadVectorRangeBoundariesStruct.*|::"
+                                "Impl::TeamThreadRangeBoundariesStruct.*"))));
+
+  auto Lambda = expr(hasType(cxxRecordDecl(isLambda()).bind("Lambda")));
+
+  Finder->addMatcher(
+      callExpr(isKokkosParallelCall(),
+               hasAnyArgument(Lambda), unless(hasAnyArgument(isAllowedPolicy)))
+          .bind("x"),
+      this);
+}
+
+void ImplicitThisCaptureCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  auto const *CE = Result.Nodes.getNodeAs<CallExpr>("x");
+
+  if (CheckIfExplicitHost) {
+    if (explicitlyUsingHostExecutionSpace(CE, HostTypeDefRegex)) {
+      return;
+    }
+  }
+
+  auto const *Lambda = Result.Nodes.getNodeAs<CXXRecordDecl>("Lambda");
+  auto CaptureLocation = capturesThis(Lambda);
+  if (CaptureLocation) {
+    diag(Lambda->getBeginLoc(), "Lambda passed to %0 implicitly captures this.")
+        << CE->getDirectCallee()->getName();
+    diag(CaptureLocation.getValue(), "the captured variable is used here.",
+         DiagnosticIDs::Note);
+    diag(CE->getBeginLoc(), "Kokkos call here.", DiagnosticIDs::Note);
+  }
+}
+
+} // namespace kokkos
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.h
+++ b/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.h
@@ -1,0 +1,41 @@
+//===--- ImplicitThisCaptureCheck.h - clang-tidy ----------------*- C++ -*-===//
+// 
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_KOKKOS_IMPLICITTHISCAPTURECHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_KOKKOS_IMPLICITTHISCAPTURECHECK_H
+
+#include "../ClangTidyCheck.h"
+
+#include <string>
+
+namespace clang {
+namespace tidy {
+namespace kokkos {
+
+/// Check to detect when a lambda passed to a ::Kokkos::parallel_* implicitly
+/// captures the this pointer
+class ImplicitThisCaptureCheck : public ClangTidyCheck {
+public:
+  ImplicitThisCaptureCheck(StringRef Name, ClangTidyContext *Context);
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+private:
+  int CheckIfExplicitHost;
+  std::string HostTypeDefRegex;
+};
+
+} // namespace kokkos
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_KOKKOS_IMPLICITTHISCAPTURECHECK_H

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.cpp
@@ -1,0 +1,54 @@
+//===--- KokkosMatchers.cpp - clang-tidy ------------------------===//
+//
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "KokkosMatchers.h"
+
+namespace clang {
+namespace tidy {
+namespace kokkos {
+
+bool explicitlyUsingHostExecutionSpace(CallExpr const *CE,
+                                       std::string const &RegexString) {
+  using namespace clang::ast_matchers;
+  auto &Ctx = CE->getCalleeDecl()->getASTContext();
+
+  // We will assume that any policy where the user might explicitly ask for the
+  // host space inherits from Impl::PolicyTraits
+  auto FilterArgs =
+      hasAnyArgument(expr(hasType(cxxRecordDecl(isDerivedFrom(cxxRecordDecl(
+                              matchesName("Impl::PolicyTraits"))))))
+                         .bind("expr"));
+
+  // We have to jump through some hoops to find this, if we just looked at the
+  // template type of the Policy constructor we lose the sugar and instead of
+  // Kokkos::DefaultHostExecutionSpace we get what the ever the typedef was set
+  // to such as Kokkos::Serial, preventing us from figuring out if the user
+  // actually asked for a host space specifically or just happens to have a
+  // host space as the default space.
+  llvm::Regex Reg(RegexString);
+  auto BNs = match(callExpr(FilterArgs).bind("CE"), *CE, Ctx);
+  for (auto &BN : BNs) {
+    if (auto const *E = BN.getNodeAs<Expr>("expr")) {
+      if (auto const *TST = E->getType()->getAs<TemplateSpecializationType>()) {
+        if (Reg.match(TST->getArg(0).getAsType().getAsString())) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+} // namespace kokkos
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
@@ -1,0 +1,52 @@
+//===--- KokkosMatchers.h - clang-tidy ------------------------===//
+//
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_KOKKOS_KOKKOSMATCHERS_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_KOKKOS_KOKKOSMATCHERS_H
+
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include <string>
+
+namespace clang {
+namespace tidy {
+namespace kokkos {
+
+AST_MATCHER_FUNCTION(ast_matchers::internal::Matcher<FunctionDecl>,
+                     kokkosParallelXFunctionDecl) {
+  using namespace clang::ast_matchers;
+  return functionDecl(matchesName("::Kokkos::parallel_.*"));
+}
+
+AST_MATCHER(CallExpr, isKokkosParallelCall) {
+  using namespace clang::ast_matchers;
+  if (auto const *FD = Node.getDirectCallee()) {
+    std::string Name = FD->getQualifiedNameAsString();
+    StringRef SR(Name);
+    if (SR.startswith("::Kokkos::parallel_")) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool explicitlyUsingHostExecutionSpace(CallExpr const *CE,
+                                       std::string const &RegexString);
+
+
+} // namespace kokkos
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_KOKKOS_KOKKOSMATCHERS_H

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosTidyModule.cpp
@@ -1,0 +1,41 @@
+//===--- KokkosTidyModule.cpp - clang-tidy ----------------------------------===//
+//
+// Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../ClangTidy.h"
+#include "../ClangTidyModule.h"
+#include "../ClangTidyModuleRegistry.h"
+#include "ImplicitThisCaptureCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace kokkos {
+
+class KokkosModule : public ClangTidyModule {
+public:
+  void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<ImplicitThisCaptureCheck>(
+        "kokkos-implicit-this-capture");
+  }
+};
+
+} // namespace kokkos
+
+// Register the DarwinTidyModule using this statically initialized variable.
+static ClangTidyModuleRegistry::Add<kokkos::KokkosModule>
+    X("kokkos-module", "Adds Kokkos specific linting checks.");
+
+// This anchor is used to force the linker to link in the generated object file
+// and thus register the KokkosModule.
+volatile int KokkosModuleAnchorSource = 0;
+
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -120,6 +120,11 @@ New checks
   Flags use of the `C` standard library functions ``memset``, ``memcpy`` and
   ``memcmp`` and similar derivatives on non-trivial types.
 
+- New :doc:`kokkos-implicit-this-capture
+  <clang-tidy/checks/kokkos-implicit-this-capture>` check.
+
+  New check for implicit this capture detection
+
 - New :doc:`llvmlibc-callee-namespace
   <clang-tidy/checks/llvmlibc-callee-namespace>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/kokkos-implicit-this-capture.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/kokkos-implicit-this-capture.rst
@@ -1,0 +1,19 @@
+.. title:: clang-tidy - kokkos-implicit-this-capture
+
+kokkos-implicit-this-capture
+============================
+
+The implicit-this-capture check checks if a lambda passed to any of
+parallel_reduce, parallel_for, or parallel_scan functions captures the this
+pointer.
+
+Example of a class that should trigger the check
+.. code-block:: c++
+  
+  class Foo {
+    int x = 0; 
+
+    void operator()(){
+      Kokkos::parallel_for(10, KOKKOS_LAMBDA(int y){ printf("%d", x+y)});
+    }
+  };

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -12,28 +12,28 @@ Clang-Tidy Checks
 .. csv-table::
    :header: "Name", "Offers fixes"
 
-   `abseil-duration-addition <abseil-duration-addition.html>`_, "Yes"
-   `abseil-duration-comparison <abseil-duration-comparison.html>`_, "Yes"
-   `abseil-duration-conversion-cast <abseil-duration-conversion-cast.html>`_, "Yes"
-   `abseil-duration-division <abseil-duration-division.html>`_, "Yes"
-   `abseil-duration-factory-float <abseil-duration-factory-float.html>`_, "Yes"
-   `abseil-duration-factory-scale <abseil-duration-factory-scale.html>`_, "Yes"
-   `abseil-duration-subtraction <abseil-duration-subtraction.html>`_, "Yes"
-   `abseil-duration-unnecessary-conversion <abseil-duration-unnecessary-conversion.html>`_, "Yes"
-   `abseil-faster-strsplit-delimiter <abseil-faster-strsplit-delimiter.html>`_, "Yes"
+   `abseil-duration-addition <abseil-duration-addition.html>`_,
+   `abseil-duration-comparison <abseil-duration-comparison.html>`_,
+   `abseil-duration-conversion-cast <abseil-duration-conversion-cast.html>`_,
+   `abseil-duration-division <abseil-duration-division.html>`_,
+   `abseil-duration-factory-float <abseil-duration-factory-float.html>`_,
+   `abseil-duration-factory-scale <abseil-duration-factory-scale.html>`_,
+   `abseil-duration-subtraction <abseil-duration-subtraction.html>`_,
+   `abseil-duration-unnecessary-conversion <abseil-duration-unnecessary-conversion.html>`_,
+   `abseil-faster-strsplit-delimiter <abseil-faster-strsplit-delimiter.html>`_,
    `abseil-no-internal-dependencies <abseil-no-internal-dependencies.html>`_,
    `abseil-no-namespace <abseil-no-namespace.html>`_,
-   `abseil-redundant-strcat-calls <abseil-redundant-strcat-calls.html>`_, "Yes"
-   `abseil-str-cat-append <abseil-str-cat-append.html>`_, "Yes"
-   `abseil-string-find-startswith <abseil-string-find-startswith.html>`_, "Yes"
-   `abseil-string-find-str-contains <abseil-string-find-str-contains.html>`_, "Yes"
-   `abseil-time-comparison <abseil-time-comparison.html>`_, "Yes"
-   `abseil-time-subtraction <abseil-time-subtraction.html>`_, "Yes"
-   `abseil-upgrade-duration-conversions <abseil-upgrade-duration-conversions.html>`_, "Yes"
-   `android-cloexec-accept <android-cloexec-accept.html>`_, "Yes"
+   `abseil-redundant-strcat-calls <abseil-redundant-strcat-calls.html>`_,
+   `abseil-str-cat-append <abseil-str-cat-append.html>`_,
+   `abseil-string-find-startswith <abseil-string-find-startswith.html>`_,
+   `abseil-string-find-str-contains <abseil-string-find-str-contains.html>`_,
+   `abseil-time-comparison <abseil-time-comparison.html>`_,
+   `abseil-time-subtraction <abseil-time-subtraction.html>`_,
+   `abseil-upgrade-duration-conversions <abseil-upgrade-duration-conversions.html>`_,
+   `android-cloexec-accept <android-cloexec-accept.html>`_,
    `android-cloexec-accept4 <android-cloexec-accept4.html>`_,
-   `android-cloexec-creat <android-cloexec-creat.html>`_, "Yes"
-   `android-cloexec-dup <android-cloexec-dup.html>`_, "Yes"
+   `android-cloexec-creat <android-cloexec-creat.html>`_,
+   `android-cloexec-dup <android-cloexec-dup.html>`_,
    `android-cloexec-epoll-create <android-cloexec-epoll-create.html>`_,
    `android-cloexec-epoll-create1 <android-cloexec-epoll-create1.html>`_,
    `android-cloexec-fopen <android-cloexec-fopen.html>`_,
@@ -41,63 +41,63 @@ Clang-Tidy Checks
    `android-cloexec-inotify-init1 <android-cloexec-inotify-init1.html>`_,
    `android-cloexec-memfd-create <android-cloexec-memfd-create.html>`_,
    `android-cloexec-open <android-cloexec-open.html>`_,
-   `android-cloexec-pipe <android-cloexec-pipe.html>`_, "Yes"
+   `android-cloexec-pipe <android-cloexec-pipe.html>`_,
    `android-cloexec-pipe2 <android-cloexec-pipe2.html>`_,
    `android-cloexec-socket <android-cloexec-socket.html>`_,
    `android-comparison-in-temp-failure-retry <android-comparison-in-temp-failure-retry.html>`_,
-   `boost-use-to-string <boost-use-to-string.html>`_, "Yes"
-   `bugprone-argument-comment <bugprone-argument-comment.html>`_, "Yes"
+   `boost-use-to-string <boost-use-to-string.html>`_,
+   `bugprone-argument-comment <bugprone-argument-comment.html>`_,
    `bugprone-assert-side-effect <bugprone-assert-side-effect.html>`_,
    `bugprone-bad-signal-to-kill-thread <bugprone-bad-signal-to-kill-thread.html>`_,
-   `bugprone-bool-pointer-implicit-conversion <bugprone-bool-pointer-implicit-conversion.html>`_, "Yes"
+   `bugprone-bool-pointer-implicit-conversion <bugprone-bool-pointer-implicit-conversion.html>`_,
    `bugprone-branch-clone <bugprone-branch-clone.html>`_,
-   `bugprone-copy-constructor-init <bugprone-copy-constructor-init.html>`_, "Yes"
+   `bugprone-copy-constructor-init <bugprone-copy-constructor-init.html>`_,
    `bugprone-dangling-handle <bugprone-dangling-handle.html>`_,
    `bugprone-dynamic-static-initializers <bugprone-dynamic-static-initializers.html>`_,
    `bugprone-exception-escape <bugprone-exception-escape.html>`_,
    `bugprone-fold-init-type <bugprone-fold-init-type.html>`_,
    `bugprone-forward-declaration-namespace <bugprone-forward-declaration-namespace.html>`_,
    `bugprone-forwarding-reference-overload <bugprone-forwarding-reference-overload.html>`_,
-   `bugprone-inaccurate-erase <bugprone-inaccurate-erase.html>`_, "Yes"
+   `bugprone-inaccurate-erase <bugprone-inaccurate-erase.html>`_,
    `bugprone-incorrect-roundings <bugprone-incorrect-roundings.html>`_,
    `bugprone-infinite-loop <bugprone-infinite-loop.html>`_,
    `bugprone-integer-division <bugprone-integer-division.html>`_,
    `bugprone-lambda-function-name <bugprone-lambda-function-name.html>`_,
-   `bugprone-macro-parentheses <bugprone-macro-parentheses.html>`_, "Yes"
+   `bugprone-macro-parentheses <bugprone-macro-parentheses.html>`_,
    `bugprone-macro-repeated-side-effects <bugprone-macro-repeated-side-effects.html>`_,
-   `bugprone-misplaced-operator-in-strlen-in-alloc <bugprone-misplaced-operator-in-strlen-in-alloc.html>`_, "Yes"
-   `bugprone-misplaced-pointer-arithmetic-in-alloc <bugprone-misplaced-pointer-arithmetic-in-alloc.html>`_, "Yes"
+   `bugprone-misplaced-operator-in-strlen-in-alloc <bugprone-misplaced-operator-in-strlen-in-alloc.html>`_,
+   `bugprone-misplaced-pointer-arithmetic-in-alloc <bugprone-misplaced-pointer-arithmetic-in-alloc.html>`_,
    `bugprone-misplaced-widening-cast <bugprone-misplaced-widening-cast.html>`_,
-   `bugprone-move-forwarding-reference <bugprone-move-forwarding-reference.html>`_, "Yes"
+   `bugprone-move-forwarding-reference <bugprone-move-forwarding-reference.html>`_,
    `bugprone-multiple-statement-macro <bugprone-multiple-statement-macro.html>`_,
-   `bugprone-not-null-terminated-result <bugprone-not-null-terminated-result.html>`_, "Yes"
-   `bugprone-parent-virtual-call <bugprone-parent-virtual-call.html>`_, "Yes"
-   `bugprone-posix-return <bugprone-posix-return.html>`_, "Yes"
-   `bugprone-reserved-identifier <bugprone-reserved-identifier.html>`_, "Yes"
+   `bugprone-not-null-terminated-result <bugprone-not-null-terminated-result.html>`_,
+   `bugprone-parent-virtual-call <bugprone-parent-virtual-call.html>`_,
+   `bugprone-posix-return <bugprone-posix-return.html>`_,
+   `bugprone-reserved-identifier <bugprone-reserved-identifier.html>`_,
    `bugprone-signed-char-misuse <bugprone-signed-char-misuse.html>`_,
    `bugprone-sizeof-container <bugprone-sizeof-container.html>`_,
    `bugprone-sizeof-expression <bugprone-sizeof-expression.html>`_,
    `bugprone-spuriously-wake-up-functions <bugprone-spuriously-wake-up-functions.html>`_,
-   `bugprone-string-constructor <bugprone-string-constructor.html>`_, "Yes"
-   `bugprone-string-integer-assignment <bugprone-string-integer-assignment.html>`_, "Yes"
+   `bugprone-string-constructor <bugprone-string-constructor.html>`_,
+   `bugprone-string-integer-assignment <bugprone-string-integer-assignment.html>`_,
    `bugprone-string-literal-with-embedded-nul <bugprone-string-literal-with-embedded-nul.html>`_,
    `bugprone-suspicious-enum-usage <bugprone-suspicious-enum-usage.html>`_,
    `bugprone-suspicious-include <bugprone-suspicious-include.html>`_,
-   `bugprone-suspicious-memset-usage <bugprone-suspicious-memset-usage.html>`_, "Yes"
+   `bugprone-suspicious-memset-usage <bugprone-suspicious-memset-usage.html>`_,
    `bugprone-suspicious-missing-comma <bugprone-suspicious-missing-comma.html>`_,
-   `bugprone-suspicious-semicolon <bugprone-suspicious-semicolon.html>`_, "Yes"
-   `bugprone-suspicious-string-compare <bugprone-suspicious-string-compare.html>`_, "Yes"
-   `bugprone-swapped-arguments <bugprone-swapped-arguments.html>`_, "Yes"
-   `bugprone-terminating-continue <bugprone-terminating-continue.html>`_, "Yes"
+   `bugprone-suspicious-semicolon <bugprone-suspicious-semicolon.html>`_,
+   `bugprone-suspicious-string-compare <bugprone-suspicious-string-compare.html>`_,
+   `bugprone-swapped-arguments <bugprone-swapped-arguments.html>`_,
+   `bugprone-terminating-continue <bugprone-terminating-continue.html>`_,
    `bugprone-throw-keyword-missing <bugprone-throw-keyword-missing.html>`_,
    `bugprone-too-small-loop-variable <bugprone-too-small-loop-variable.html>`_,
    `bugprone-undefined-memory-manipulation <bugprone-undefined-memory-manipulation.html>`_,
    `bugprone-undelegated-constructor <bugprone-undelegated-constructor.html>`_,
    `bugprone-unhandled-self-assignment <bugprone-unhandled-self-assignment.html>`_,
-   `bugprone-unused-raii <bugprone-unused-raii.html>`_, "Yes"
+   `bugprone-unused-raii <bugprone-unused-raii.html>`_,
    `bugprone-unused-return-value <bugprone-unused-return-value.html>`_,
    `bugprone-use-after-move <bugprone-use-after-move.html>`_,
-   `bugprone-virtual-near-miss <bugprone-virtual-near-miss.html>`_, "Yes"
+   `bugprone-virtual-near-miss <bugprone-virtual-near-miss.html>`_,
    `cert-dcl21-cpp <cert-dcl21-cpp.html>`_,
    `cert-dcl50-cpp <cert-dcl50-cpp.html>`_,
    `cert-dcl58-cpp <cert-dcl58-cpp.html>`_,
@@ -133,28 +133,29 @@ Clang-Tidy Checks
    `clang-analyzer-valist.Uninitialized <clang-analyzer-valist.Uninitialized.html>`_,
    `clang-analyzer-valist.Unterminated <clang-analyzer-valist.Unterminated.html>`_,
    `cppcoreguidelines-avoid-goto <cppcoreguidelines-avoid-goto.html>`_,
-   `cppcoreguidelines-init-variables <cppcoreguidelines-init-variables.html>`_, "Yes"
+   `cppcoreguidelines-avoid-non-const-global-variables <cppcoreguidelines-avoid-non-const-global-variables.html>`_,
+   `cppcoreguidelines-init-variables <cppcoreguidelines-init-variables.html>`_,
    `cppcoreguidelines-interfaces-global-init <cppcoreguidelines-interfaces-global-init.html>`_,
    `cppcoreguidelines-macro-usage <cppcoreguidelines-macro-usage.html>`_,
    `cppcoreguidelines-narrowing-conversions <cppcoreguidelines-narrowing-conversions.html>`_,
    `cppcoreguidelines-no-malloc <cppcoreguidelines-no-malloc.html>`_,
    `cppcoreguidelines-owning-memory <cppcoreguidelines-owning-memory.html>`_,
    `cppcoreguidelines-pro-bounds-array-to-pointer-decay <cppcoreguidelines-pro-bounds-array-to-pointer-decay.html>`_,
-   `cppcoreguidelines-pro-bounds-constant-array-index <cppcoreguidelines-pro-bounds-constant-array-index.html>`_, "Yes"
+   `cppcoreguidelines-pro-bounds-constant-array-index <cppcoreguidelines-pro-bounds-constant-array-index.html>`_,
    `cppcoreguidelines-pro-bounds-pointer-arithmetic <cppcoreguidelines-pro-bounds-pointer-arithmetic.html>`_,
    `cppcoreguidelines-pro-type-const-cast <cppcoreguidelines-pro-type-const-cast.html>`_,
-   `cppcoreguidelines-pro-type-cstyle-cast <cppcoreguidelines-pro-type-cstyle-cast.html>`_, "Yes"
-   `cppcoreguidelines-pro-type-member-init <cppcoreguidelines-pro-type-member-init.html>`_, "Yes"
+   `cppcoreguidelines-pro-type-cstyle-cast <cppcoreguidelines-pro-type-cstyle-cast.html>`_,
+   `cppcoreguidelines-pro-type-member-init <cppcoreguidelines-pro-type-member-init.html>`_,
    `cppcoreguidelines-pro-type-reinterpret-cast <cppcoreguidelines-pro-type-reinterpret-cast.html>`_,
-   `cppcoreguidelines-pro-type-static-cast-downcast <cppcoreguidelines-pro-type-static-cast-downcast.html>`_, "Yes"
+   `cppcoreguidelines-pro-type-static-cast-downcast <cppcoreguidelines-pro-type-static-cast-downcast.html>`_,
    `cppcoreguidelines-pro-type-union-access <cppcoreguidelines-pro-type-union-access.html>`_,
    `cppcoreguidelines-pro-type-vararg <cppcoreguidelines-pro-type-vararg.html>`_,
    `cppcoreguidelines-slicing <cppcoreguidelines-slicing.html>`_,
    `cppcoreguidelines-special-member-functions <cppcoreguidelines-special-member-functions.html>`_,
    `darwin-avoid-spinlock <darwin-avoid-spinlock.html>`_,
-   `darwin-dispatch-once-nonstatic <darwin-dispatch-once-nonstatic.html>`_, "Yes"
+   `darwin-dispatch-once-nonstatic <darwin-dispatch-once-nonstatic.html>`_,
    `fuchsia-default-arguments-calls <fuchsia-default-arguments-calls.html>`_,
-   `fuchsia-default-arguments-declarations <fuchsia-default-arguments-declarations.html>`_, "Yes"
+   `fuchsia-default-arguments-declarations <fuchsia-default-arguments-declarations.html>`_,
    `fuchsia-multiple-inheritance <fuchsia-multiple-inheritance.html>`_,
    `fuchsia-overloaded-operator <fuchsia-overloaded-operator.html>`_,
    `fuchsia-statically-constructed-objects <fuchsia-statically-constructed-objects.html>`_,
@@ -164,7 +165,7 @@ Clang-Tidy Checks
    `google-build-namespaces <google-build-namespaces.html>`_,
    `google-build-using-namespace <google-build-using-namespace.html>`_,
    `google-default-arguments <google-default-arguments.html>`_,
-   `google-explicit-constructor <google-explicit-constructor.html>`_, "Yes"
+   `google-explicit-constructor <google-explicit-constructor.html>`_,
    `google-global-names-in-headers <google-global-names-in-headers.html>`_,
    `google-objc-avoid-nsobject-new <google-objc-avoid-nsobject-new.html>`_,
    `google-objc-avoid-throwing-exception <google-objc-avoid-throwing-exception.html>`_,
@@ -176,131 +177,132 @@ Clang-Tidy Checks
    `google-runtime-int <google-runtime-int.html>`_,
    `google-runtime-operator <google-runtime-operator.html>`_,
    `google-runtime-references <google-runtime-references.html>`_,
-   `google-upgrade-googletest-case <google-upgrade-googletest-case.html>`_, "Yes"
+   `google-upgrade-googletest-case <google-upgrade-googletest-case.html>`_,
    `hicpp-avoid-goto <hicpp-avoid-goto.html>`_,
    `hicpp-exception-baseclass <hicpp-exception-baseclass.html>`_,
    `hicpp-multiway-paths-covered <hicpp-multiway-paths-covered.html>`_,
    `hicpp-no-assembler <hicpp-no-assembler.html>`_,
    `hicpp-signed-bitwise <hicpp-signed-bitwise.html>`_,
+   `kokkos-implicit-this-capture <kokkos-implicit-this-capture.html>`_,
    `linuxkernel-must-use-errs <linuxkernel-must-use-errs.html>`_,
    `llvm-header-guard <llvm-header-guard.html>`_,
-   `llvm-include-order <llvm-include-order.html>`_, "Yes"
+   `llvm-include-order <llvm-include-order.html>`_,
    `llvm-namespace-comment <llvm-namespace-comment.html>`_,
-   `llvm-prefer-isa-or-dyn-cast-in-conditionals <llvm-prefer-isa-or-dyn-cast-in-conditionals.html>`_, "Yes"
-   `llvm-prefer-register-over-unsigned <llvm-prefer-register-over-unsigned.html>`_, "Yes"
-   `llvm-twine-local <llvm-twine-local.html>`_, "Yes"
-   `llvmlibc-callee-namespace <llvmlibc-calle-namespace.html>`_,
+   `llvm-prefer-isa-or-dyn-cast-in-conditionals <llvm-prefer-isa-or-dyn-cast-in-conditionals.html>`_,
+   `llvm-prefer-register-over-unsigned <llvm-prefer-register-over-unsigned.html>`_,
+   `llvm-twine-local <llvm-twine-local.html>`_,
+   `llvmlibc-callee-namespace <llvmlibc-callee-namespace.html>`_,
    `llvmlibc-implementation-in-namespace <llvmlibc-implementation-in-namespace.html>`_,
-   `llvmlibc-restrict-system-libc-headers <llvmlibc-restrict-system-libc-headers.html>`_, "Yes"
-   `misc-definitions-in-headers <misc-definitions-in-headers.html>`_, "Yes"
+   `llvmlibc-restrict-system-libc-headers <llvmlibc-restrict-system-libc-headers.html>`_,
+   `misc-definitions-in-headers <misc-definitions-in-headers.html>`_,
    `misc-misplaced-const <misc-misplaced-const.html>`_,
    `misc-new-delete-overloads <misc-new-delete-overloads.html>`_,
    `misc-no-recursion <misc-no-recursion.html>`_,
    `misc-non-copyable-objects <misc-non-copyable-objects.html>`_,
    `misc-non-private-member-variables-in-classes <misc-non-private-member-variables-in-classes.html>`_,
-   `misc-redundant-expression <misc-redundant-expression.html>`_, "Yes"
-   `misc-static-assert <misc-static-assert.html>`_, "Yes"
+   `misc-redundant-expression <misc-redundant-expression.html>`_,
+   `misc-static-assert <misc-static-assert.html>`_,
    `misc-throw-by-value-catch-by-reference <misc-throw-by-value-catch-by-reference.html>`_,
    `misc-unconventional-assign-operator <misc-unconventional-assign-operator.html>`_,
-   `misc-uniqueptr-reset-release <misc-uniqueptr-reset-release.html>`_, "Yes"
-   `misc-unused-alias-decls <misc-unused-alias-decls.html>`_, "Yes"
-   `misc-unused-parameters <misc-unused-parameters.html>`_, "Yes"
-   `misc-unused-using-decls <misc-unused-using-decls.html>`_, "Yes"
-   `modernize-avoid-bind <modernize-avoid-bind.html>`_, "Yes"
+   `misc-uniqueptr-reset-release <misc-uniqueptr-reset-release.html>`_,
+   `misc-unused-alias-decls <misc-unused-alias-decls.html>`_,
+   `misc-unused-parameters <misc-unused-parameters.html>`_,
+   `misc-unused-using-decls <misc-unused-using-decls.html>`_,
+   `modernize-avoid-bind <modernize-avoid-bind.html>`_,
    `modernize-avoid-c-arrays <modernize-avoid-c-arrays.html>`_,
-   `modernize-concat-nested-namespaces <modernize-concat-nested-namespaces.html>`_, "Yes"
-   `modernize-deprecated-headers <modernize-deprecated-headers.html>`_, "Yes"
-   `modernize-deprecated-ios-base-aliases <modernize-deprecated-ios-base-aliases.html>`_, "Yes"
-   `modernize-loop-convert <modernize-loop-convert.html>`_, "Yes"
-   `modernize-make-shared <modernize-make-shared.html>`_, "Yes"
-   `modernize-make-unique <modernize-make-unique.html>`_, "Yes"
-   `modernize-pass-by-value <modernize-pass-by-value.html>`_, "Yes"
-   `modernize-raw-string-literal <modernize-raw-string-literal.html>`_, "Yes"
-   `modernize-redundant-void-arg <modernize-redundant-void-arg.html>`_, "Yes"
-   `modernize-replace-auto-ptr <modernize-replace-auto-ptr.html>`_, "Yes"
-   `modernize-replace-disallow-copy-and-assign-macro <modernize-replace-disallow-copy-and-assign-macro.html>`_, "Yes"
-   `modernize-replace-random-shuffle <modernize-replace-random-shuffle.html>`_, "Yes"
-   `modernize-return-braced-init-list <modernize-return-braced-init-list.html>`_, "Yes"
-   `modernize-shrink-to-fit <modernize-shrink-to-fit.html>`_, "Yes"
-   `modernize-unary-static-assert <modernize-unary-static-assert.html>`_, "Yes"
-   `modernize-use-auto <modernize-use-auto.html>`_, "Yes"
-   `modernize-use-bool-literals <modernize-use-bool-literals.html>`_, "Yes"
-   `modernize-use-default-member-init <modernize-use-default-member-init.html>`_, "Yes"
-   `modernize-use-emplace <modernize-use-emplace.html>`_, "Yes"
-   `modernize-use-equals-default <modernize-use-equals-default.html>`_, "Yes"
-   `modernize-use-equals-delete <modernize-use-equals-delete.html>`_, "Yes"
-   `modernize-use-nodiscard <modernize-use-nodiscard.html>`_, "Yes"
-   `modernize-use-noexcept <modernize-use-noexcept.html>`_, "Yes"
-   `modernize-use-nullptr <modernize-use-nullptr.html>`_, "Yes"
-   `modernize-use-override <modernize-use-override.html>`_, "Yes"
-   `modernize-use-trailing-return-type <modernize-use-trailing-return-type.html>`_, "Yes"
-   `modernize-use-transparent-functors <modernize-use-transparent-functors.html>`_, "Yes"
-   `modernize-use-uncaught-exceptions <modernize-use-uncaught-exceptions.html>`_, "Yes"
-   `modernize-use-using <modernize-use-using.html>`_, "Yes"
-   `mpi-buffer-deref <mpi-buffer-deref.html>`_, "Yes"
-   `mpi-type-mismatch <mpi-type-mismatch.html>`_, "Yes"
+   `modernize-concat-nested-namespaces <modernize-concat-nested-namespaces.html>`_,
+   `modernize-deprecated-headers <modernize-deprecated-headers.html>`_,
+   `modernize-deprecated-ios-base-aliases <modernize-deprecated-ios-base-aliases.html>`_,
+   `modernize-loop-convert <modernize-loop-convert.html>`_,
+   `modernize-make-shared <modernize-make-shared.html>`_,
+   `modernize-make-unique <modernize-make-unique.html>`_,
+   `modernize-pass-by-value <modernize-pass-by-value.html>`_,
+   `modernize-raw-string-literal <modernize-raw-string-literal.html>`_,
+   `modernize-redundant-void-arg <modernize-redundant-void-arg.html>`_,
+   `modernize-replace-auto-ptr <modernize-replace-auto-ptr.html>`_,
+   `modernize-replace-disallow-copy-and-assign-macro <modernize-replace-disallow-copy-and-assign-macro.html>`_,
+   `modernize-replace-random-shuffle <modernize-replace-random-shuffle.html>`_,
+   `modernize-return-braced-init-list <modernize-return-braced-init-list.html>`_,
+   `modernize-shrink-to-fit <modernize-shrink-to-fit.html>`_,
+   `modernize-unary-static-assert <modernize-unary-static-assert.html>`_,
+   `modernize-use-auto <modernize-use-auto.html>`_,
+   `modernize-use-bool-literals <modernize-use-bool-literals.html>`_,
+   `modernize-use-default-member-init <modernize-use-default-member-init.html>`_,
+   `modernize-use-emplace <modernize-use-emplace.html>`_,
+   `modernize-use-equals-default <modernize-use-equals-default.html>`_,
+   `modernize-use-equals-delete <modernize-use-equals-delete.html>`_,
+   `modernize-use-nodiscard <modernize-use-nodiscard.html>`_,
+   `modernize-use-noexcept <modernize-use-noexcept.html>`_,
+   `modernize-use-nullptr <modernize-use-nullptr.html>`_,
+   `modernize-use-override <modernize-use-override.html>`_,
+   `modernize-use-trailing-return-type <modernize-use-trailing-return-type.html>`_,
+   `modernize-use-transparent-functors <modernize-use-transparent-functors.html>`_,
+   `modernize-use-uncaught-exceptions <modernize-use-uncaught-exceptions.html>`_,
+   `modernize-use-using <modernize-use-using.html>`_,
+   `mpi-buffer-deref <mpi-buffer-deref.html>`_,
+   `mpi-type-mismatch <mpi-type-mismatch.html>`_,
    `objc-avoid-nserror-init <objc-avoid-nserror-init.html>`_,
    `objc-dealloc-in-category <objc-dealloc-in-category.html>`_,
    `objc-forbidden-subclassing <objc-forbidden-subclassing.html>`_,
    `objc-missing-hash <objc-missing-hash.html>`_,
-   `objc-nsinvocation-argument-lifetime <objc-nsinvocation-argument-lifetime.html>`_, "Yes"
-   `objc-property-declaration <objc-property-declaration.html>`_, "Yes"
-   `objc-super-self <objc-super-self.html>`_, "Yes"
+   `objc-nsinvocation-argument-lifetime <objc-nsinvocation-argument-lifetime.html>`_,
+   `objc-property-declaration <objc-property-declaration.html>`_,
+   `objc-super-self <objc-super-self.html>`_,
    `openmp-exception-escape <openmp-exception-escape.html>`_,
    `openmp-use-default-none <openmp-use-default-none.html>`_,
-   `performance-faster-string-find <performance-faster-string-find.html>`_, "Yes"
-   `performance-for-range-copy <performance-for-range-copy.html>`_, "Yes"
+   `performance-faster-string-find <performance-faster-string-find.html>`_,
+   `performance-for-range-copy <performance-for-range-copy.html>`_,
    `performance-implicit-conversion-in-loop <performance-implicit-conversion-in-loop.html>`_,
-   `performance-inefficient-algorithm <performance-inefficient-algorithm.html>`_, "Yes"
+   `performance-inefficient-algorithm <performance-inefficient-algorithm.html>`_,
    `performance-inefficient-string-concatenation <performance-inefficient-string-concatenation.html>`_,
-   `performance-inefficient-vector-operation <performance-inefficient-vector-operation.html>`_, "Yes"
-   `performance-move-const-arg <performance-move-const-arg.html>`_, "Yes"
-   `performance-move-constructor-init <performance-move-constructor-init.html>`_, "Yes"
+   `performance-inefficient-vector-operation <performance-inefficient-vector-operation.html>`_,
+   `performance-move-const-arg <performance-move-const-arg.html>`_,
+   `performance-move-constructor-init <performance-move-constructor-init.html>`_,
    `performance-no-automatic-move <performance-no-automatic-move.html>`_,
-   `performance-noexcept-move-constructor <performance-noexcept-move-constructor.html>`_, "Yes"
-   `performance-trivially-destructible <performance-trivially-destructible.html>`_, "Yes"
-   `performance-type-promotion-in-math-fn <performance-type-promotion-in-math-fn.html>`_, "Yes"
+   `performance-noexcept-move-constructor <performance-noexcept-move-constructor.html>`_,
+   `performance-trivially-destructible <performance-trivially-destructible.html>`_,
+   `performance-type-promotion-in-math-fn <performance-type-promotion-in-math-fn.html>`_,
    `performance-unnecessary-copy-initialization <performance-unnecessary-copy-initialization.html>`_,
-   `performance-unnecessary-value-param <performance-unnecessary-value-param.html>`_, "Yes"
-   `portability-restrict-system-includes <portability-restrict-system-includes.html>`_, "Yes"
+   `performance-unnecessary-value-param <performance-unnecessary-value-param.html>`_,
+   `portability-restrict-system-includes <portability-restrict-system-includes.html>`_,
    `portability-simd-intrinsics <portability-simd-intrinsics.html>`_,
    `readability-avoid-const-params-in-decls <readability-avoid-const-params-in-decls.html>`_,
-   `readability-braces-around-statements <readability-braces-around-statements.html>`_, "Yes"
-   `readability-const-return-type <readability-const-return-type.html>`_, "Yes"
-   `readability-container-size-empty <readability-container-size-empty.html>`_, "Yes"
+   `readability-braces-around-statements <readability-braces-around-statements.html>`_,
+   `readability-const-return-type <readability-const-return-type.html>`_,
+   `readability-container-size-empty <readability-container-size-empty.html>`_,
    `readability-convert-member-functions-to-static <readability-convert-member-functions-to-static.html>`_,
-   `readability-delete-null-pointer <readability-delete-null-pointer.html>`_, "Yes"
+   `readability-delete-null-pointer <readability-delete-null-pointer.html>`_,
    `readability-deleted-default <readability-deleted-default.html>`_,
-   `readability-else-after-return <readability-else-after-return.html>`_, "Yes"
+   `readability-else-after-return <readability-else-after-return.html>`_,
    `readability-function-size <readability-function-size.html>`_,
-   `readability-identifier-naming <readability-identifier-naming.html>`_, "Yes"
-   `readability-implicit-bool-conversion <readability-implicit-bool-conversion.html>`_, "Yes"
-   `readability-inconsistent-declaration-parameter-name <readability-inconsistent-declaration-parameter-name.html>`_, "Yes"
-   `readability-isolate-declaration <readability-isolate-declaration.html>`_, "Yes"
+   `readability-identifier-naming <readability-identifier-naming.html>`_,
+   `readability-implicit-bool-conversion <readability-implicit-bool-conversion.html>`_,
+   `readability-inconsistent-declaration-parameter-name <readability-inconsistent-declaration-parameter-name.html>`_,
+   `readability-isolate-declaration <readability-isolate-declaration.html>`_,
    `readability-magic-numbers <readability-magic-numbers.html>`_,
-   `readability-make-member-function-const <readability-make-member-function-const.html>`_, "Yes"
+   `readability-make-member-function-const <readability-make-member-function-const.html>`_,
    `readability-misleading-indentation <readability-misleading-indentation.html>`_,
-   `readability-misplaced-array-index <readability-misplaced-array-index.html>`_, "Yes"
-   `readability-named-parameter <readability-named-parameter.html>`_, "Yes"
-   `readability-non-const-parameter <readability-non-const-parameter.html>`_, "Yes"
-   `readability-qualified-auto <readability-qualified-auto.html>`_, "Yes"
-   `readability-redundant-access-specifiers <readability-redundant-access-specifiers.html>`_, "Yes"
-   `readability-redundant-control-flow <readability-redundant-control-flow.html>`_, "Yes"
-   `readability-redundant-declaration <readability-redundant-declaration.html>`_, "Yes"
-   `readability-redundant-function-ptr-dereference <readability-redundant-function-ptr-dereference.html>`_, "Yes"
-   `readability-redundant-member-init <readability-redundant-member-init.html>`_, "Yes"
+   `readability-misplaced-array-index <readability-misplaced-array-index.html>`_,
+   `readability-named-parameter <readability-named-parameter.html>`_,
+   `readability-non-const-parameter <readability-non-const-parameter.html>`_,
+   `readability-qualified-auto <readability-qualified-auto.html>`_,
+   `readability-redundant-access-specifiers <readability-redundant-access-specifiers.html>`_,
+   `readability-redundant-control-flow <readability-redundant-control-flow.html>`_,
+   `readability-redundant-declaration <readability-redundant-declaration.html>`_,
+   `readability-redundant-function-ptr-dereference <readability-redundant-function-ptr-dereference.html>`_,
+   `readability-redundant-member-init <readability-redundant-member-init.html>`_,
    `readability-redundant-preprocessor <readability-redundant-preprocessor.html>`_,
-   `readability-redundant-smartptr-get <readability-redundant-smartptr-get.html>`_, "Yes"
+   `readability-redundant-smartptr-get <readability-redundant-smartptr-get.html>`_,
    `readability-redundant-string-cstr <readability-redundant-string-cstr.html>`_,
-   `readability-redundant-string-init <readability-redundant-string-init.html>`_, "Yes"
-   `readability-simplify-boolean-expr <readability-simplify-boolean-expr.html>`_, "Yes"
-   `readability-simplify-subscript-expr <readability-simplify-subscript-expr.html>`_, "Yes"
-   `readability-static-accessed-through-instance <readability-static-accessed-through-instance.html>`_, "Yes"
-   `readability-static-definition-in-anonymous-namespace <readability-static-definition-in-anonymous-namespace.html>`_, "Yes"
-   `readability-string-compare <readability-string-compare.html>`_, "Yes"
-   `readability-uniqueptr-delete-release <readability-uniqueptr-delete-release.html>`_, "Yes"
-   `readability-uppercase-literal-suffix <readability-uppercase-literal-suffix.html>`_, "Yes"
-   `readability-use-anyofallof`_, "No"
+   `readability-redundant-string-init <readability-redundant-string-init.html>`_,
+   `readability-simplify-boolean-expr <readability-simplify-boolean-expr.html>`_,
+   `readability-simplify-subscript-expr <readability-simplify-subscript-expr.html>`_,
+   `readability-static-accessed-through-instance <readability-static-accessed-through-instance.html>`_,
+   `readability-static-definition-in-anonymous-namespace <readability-static-definition-in-anonymous-namespace.html>`_,
+   `readability-string-compare <readability-string-compare.html>`_,
+   `readability-uniqueptr-delete-release <readability-uniqueptr-delete-release.html>`_,
+   `readability-uppercase-literal-suffix <readability-uppercase-literal-suffix.html>`_,
+   `readability-use-anyofallof <readability-use-anyofallof.html>`_,
    `zircon-temporary-objects <zircon-temporary-objects.html>`_,
 
 
@@ -309,10 +311,10 @@ Clang-Tidy Checks
 
    `cert-con36-c <cert-con36-c.html>`_, `bugprone-spuriously-wake-up-functions <bugprone-spuriously-wake-up-functions.html>`_,
    `cert-con54-cpp <cert-con54-cpp.html>`_, `bugprone-spuriously-wake-up-functions <bugprone-spuriously-wake-up-functions.html>`_,
-   `cert-dcl03-c <cert-dcl03-c.html>`_, `misc-static-assert <misc-static-assert.html>`_, "Yes"
-   `cert-dcl16-c <cert-dcl16-c.html>`_, `readability-uppercase-literal-suffix <readability-uppercase-literal-suffix.html>`_, "Yes"
-   `cert-dcl37-c <cert-dcl37-c.html>`_, `bugprone-reserved-identifier <bugprone-reserved-identifier.html>`_, "Yes"
-   `cert-dcl51-cpp <cert-dcl51-cpp.html>`_, `bugprone-reserved-identifier <bugprone-reserved-identifier.html>`_, "Yes"
+   `cert-dcl03-c <cert-dcl03-c.html>`_, `misc-static-assert <misc-static-assert.html>`_,
+   `cert-dcl16-c <cert-dcl16-c.html>`_, `readability-uppercase-literal-suffix <readability-uppercase-literal-suffix.html>`_,
+   `cert-dcl37-c <cert-dcl37-c.html>`_, `bugprone-reserved-identifier <bugprone-reserved-identifier.html>`_,
+   `cert-dcl51-cpp <cert-dcl51-cpp.html>`_, `bugprone-reserved-identifier <bugprone-reserved-identifier.html>`_,
    `cert-dcl54-cpp <cert-dcl54-cpp.html>`_, `misc-new-delete-overloads <misc-new-delete-overloads.html>`_,
    `cert-dcl59-cpp <cert-dcl59-cpp.html>`_, `google-build-namespaces <google-build-namespaces.html>`_,
    `cert-err09-cpp <cert-err09-cpp.html>`_, `misc-throw-by-value-catch-by-reference <misc-throw-by-value-catch-by-reference.html>`_,
@@ -320,7 +322,7 @@ Clang-Tidy Checks
    `cert-fio38-c <cert-fio38-c.html>`_, `misc-non-copyable-objects <misc-non-copyable-objects.html>`_,
    `cert-msc30-c <cert-msc30-c.html>`_, `cert-msc50-cpp <cert-msc50-cpp.html>`_,
    `cert-msc32-c <cert-msc32-c.html>`_, `cert-msc51-cpp <cert-msc51-cpp.html>`_,
-   `cert-oop11-cpp <cert-oop11-cpp.html>`_, `performance-move-constructor-init <performance-move-constructor-init.html>`_, "Yes"
+   `cert-oop11-cpp <cert-oop11-cpp.html>`_, `performance-move-constructor-init <performance-move-constructor-init.html>`_,
    `cert-oop54-cpp <cert-oop54-cpp.html>`_, `bugprone-unhandled-self-assignment <bugprone-unhandled-self-assignment.html>`_,
    `cert-pos44-c <cert-pos44-c.html>`_, `bugprone-bad-signal-to-kill-thread <bugprone-bad-signal-to-kill-thread.html>`_,
    `cert-str34-c <cert-str34-c.html>`_, `bugprone-signed-char-misuse <bugprone-signed-char-misuse.html>`_,
@@ -390,38 +392,36 @@ Clang-Tidy Checks
    `clang-analyzer-unix.cstring.NullArg <clang-analyzer-unix.cstring.NullArg.html>`_, `Clang Static Analyzer <https://clang.llvm.org/docs/analyzer/checkers.html>`_,
    `cppcoreguidelines-avoid-c-arrays <cppcoreguidelines-avoid-c-arrays.html>`_, `modernize-avoid-c-arrays <modernize-avoid-c-arrays.html>`_,
    `cppcoreguidelines-avoid-magic-numbers <cppcoreguidelines-avoid-magic-numbers.html>`_, `readability-magic-numbers <readability-magic-numbers.html>`_,
-   `cppcoreguidelines-avoid-non-const-global-variables <cppcoreguidelines-avoid-non-const-global-variables.html>`_, , , ""
    `cppcoreguidelines-c-copy-assignment-signature <cppcoreguidelines-c-copy-assignment-signature.html>`_, `misc-unconventional-assign-operator <misc-unconventional-assign-operator.html>`_,
-   `cppcoreguidelines-explicit-virtual-functions <cppcoreguidelines-explicit-virtual-functions.html>`_, `modernize-use-override <modernize-use-override.html>`_, "Yes"
+   `cppcoreguidelines-explicit-virtual-functions <cppcoreguidelines-explicit-virtual-functions.html>`_, `modernize-use-override <modernize-use-override.html>`_,
    `cppcoreguidelines-non-private-member-variables-in-classes <cppcoreguidelines-non-private-member-variables-in-classes.html>`_, `misc-non-private-member-variables-in-classes <misc-non-private-member-variables-in-classes.html>`_,
    `fuchsia-header-anon-namespaces <fuchsia-header-anon-namespaces.html>`_, `google-build-namespaces <google-build-namespaces.html>`_,
-   `google-readability-braces-around-statements <google-readability-braces-around-statements.html>`_, `readability-braces-around-statements <readability-braces-around-statements.html>`_, "Yes"
+   `google-readability-braces-around-statements <google-readability-braces-around-statements.html>`_, `readability-braces-around-statements <readability-braces-around-statements.html>`_,
    `google-readability-function-size <google-readability-function-size.html>`_, `readability-function-size <readability-function-size.html>`_,
    `google-readability-namespace-comments <google-readability-namespace-comments.html>`_, `llvm-namespace-comment <llvm-namespace-comment.html>`_,
    `hicpp-avoid-c-arrays <hicpp-avoid-c-arrays.html>`_, `modernize-avoid-c-arrays <modernize-avoid-c-arrays.html>`_,
-   `hicpp-braces-around-statements <hicpp-braces-around-statements.html>`_, `readability-braces-around-statements <readability-braces-around-statements.html>`_, "Yes"
-   `hicpp-deprecated-headers <hicpp-deprecated-headers.html>`_, `modernize-deprecated-headers <modernize-deprecated-headers.html>`_, "Yes"
-   `hicpp-explicit-conversions <hicpp-explicit-conversions.html>`_, `google-explicit-constructor <google-explicit-constructor.html>`_, "Yes"
+   `hicpp-braces-around-statements <hicpp-braces-around-statements.html>`_, `readability-braces-around-statements <readability-braces-around-statements.html>`_,
+   `hicpp-deprecated-headers <hicpp-deprecated-headers.html>`_, `modernize-deprecated-headers <modernize-deprecated-headers.html>`_,
+   `hicpp-explicit-conversions <hicpp-explicit-conversions.html>`_, `google-explicit-constructor <google-explicit-constructor.html>`_,
    `hicpp-function-size <hicpp-function-size.html>`_, `readability-function-size <readability-function-size.html>`_,
    `hicpp-invalid-access-moved <hicpp-invalid-access-moved.html>`_, `bugprone-use-after-move <bugprone-use-after-move.html>`_,
-   `hicpp-member-init <hicpp-member-init.html>`_, `cppcoreguidelines-pro-type-member-init <cppcoreguidelines-pro-type-member-init.html>`_, "Yes"
-   `hicpp-move-const-arg <hicpp-move-const-arg.html>`_, `performance-move-const-arg <performance-move-const-arg.html>`_, "Yes"
-   `hicpp-named-parameter <hicpp-named-parameter.html>`_, `readability-named-parameter <readability-named-parameter.html>`_, "Yes"
+   `hicpp-member-init <hicpp-member-init.html>`_, `cppcoreguidelines-pro-type-member-init <cppcoreguidelines-pro-type-member-init.html>`_,
+   `hicpp-move-const-arg <hicpp-move-const-arg.html>`_, `performance-move-const-arg <performance-move-const-arg.html>`_,
+   `hicpp-named-parameter <hicpp-named-parameter.html>`_, `readability-named-parameter <readability-named-parameter.html>`_,
    `hicpp-new-delete-operators <hicpp-new-delete-operators.html>`_, `misc-new-delete-overloads <misc-new-delete-overloads.html>`_,
    `hicpp-no-array-decay <hicpp-no-array-decay.html>`_, `cppcoreguidelines-pro-bounds-array-to-pointer-decay <cppcoreguidelines-pro-bounds-array-to-pointer-decay.html>`_,
    `hicpp-no-malloc <hicpp-no-malloc.html>`_, `cppcoreguidelines-no-malloc <cppcoreguidelines-no-malloc.html>`_,
    `hicpp-noexcept-move <hicpp-noexcept-move.html>`_, `performance-noexcept-move-constructor <performance-noexcept-move-constructor.html>`_,
    `hicpp-special-member-functions <hicpp-special-member-functions.html>`_, `cppcoreguidelines-special-member-functions <cppcoreguidelines-special-member-functions.html>`_,
-   `hicpp-static-assert <hicpp-static-assert.html>`_, `misc-static-assert <misc-static-assert.html>`_, "Yes"
+   `hicpp-static-assert <hicpp-static-assert.html>`_, `misc-static-assert <misc-static-assert.html>`_,
    `hicpp-undelegated-constructor <hicpp-undelegated-constructor.html>`_, `bugprone-undelegated-constructor <bugprone-undelegated-constructor.html>`_,
-   `hicpp-uppercase-literal-suffix <hicpp-uppercase-literal-suffix.html>`_, `readability-uppercase-literal-suffix <readability-uppercase-literal-suffix.html>`_, "Yes"
-   `hicpp-use-auto <hicpp-use-auto.html>`_, `modernize-use-auto <modernize-use-auto.html>`_, "Yes"
-   `hicpp-use-emplace <hicpp-use-emplace.html>`_, `modernize-use-emplace <modernize-use-emplace.html>`_, "Yes"
-   `hicpp-use-equals-default <hicpp-use-equals-default.html>`_, `modernize-use-equals-default <modernize-use-equals-default.html>`_, "Yes"
-   `hicpp-use-equals-delete <hicpp-use-equals-delete.html>`_, `modernize-use-equals-delete <modernize-use-equals-delete.html>`_, "Yes"
-   `hicpp-use-noexcept <hicpp-use-noexcept.html>`_, `modernize-use-noexcept <modernize-use-noexcept.html>`_, "Yes"
-   `hicpp-use-nullptr <hicpp-use-nullptr.html>`_, `modernize-use-nullptr <modernize-use-nullptr.html>`_, "Yes"
-   `hicpp-use-override <hicpp-use-override.html>`_, `modernize-use-override <modernize-use-override.html>`_, "Yes"
+   `hicpp-uppercase-literal-suffix <hicpp-uppercase-literal-suffix.html>`_, `readability-uppercase-literal-suffix <readability-uppercase-literal-suffix.html>`_,
+   `hicpp-use-auto <hicpp-use-auto.html>`_, `modernize-use-auto <modernize-use-auto.html>`_,
+   `hicpp-use-emplace <hicpp-use-emplace.html>`_, `modernize-use-emplace <modernize-use-emplace.html>`_,
+   `hicpp-use-equals-default <hicpp-use-equals-default.html>`_, `modernize-use-equals-default <modernize-use-equals-default.html>`_,
+   `hicpp-use-equals-delete <hicpp-use-equals-delete.html>`_, `modernize-use-equals-delete <modernize-use-equals-delete.html>`_,
+   `hicpp-use-noexcept <hicpp-use-noexcept.html>`_, `modernize-use-noexcept <modernize-use-noexcept.html>`_,
+   `hicpp-use-nullptr <hicpp-use-nullptr.html>`_, `modernize-use-nullptr <modernize-use-nullptr.html>`_,
+   `hicpp-use-override <hicpp-use-override.html>`_, `modernize-use-override <modernize-use-override.html>`_,
    `hicpp-vararg <hicpp-vararg.html>`_, `cppcoreguidelines-pro-type-vararg <cppcoreguidelines-pro-type-vararg.html>`_,
-   `llvm-qualified-auto <llvm-qualified-auto.html>`_, `readability-qualified-auto <readability-qualified-auto.html>`_, "Yes"
-
+   `llvm-qualified-auto <llvm-qualified-auto.html>`_, `readability-qualified-auto <readability-qualified-auto.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/kokkos-implicit-this-capture.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/kokkos-implicit-this-capture.cpp
@@ -1,0 +1,15 @@
+// RUN: %check_clang_tidy %s kokkos-implicit-this-capture %t
+
+// TODO Need to mock Kokkos
+// FIXME: Add something that triggers the check here.
+// void f();
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'f' is insufficiently awesome [kokkos-implicit-this-capture]
+
+// FIXME: Verify the applied fix.
+//   * Make the CHECK patterns specific enough and try to make verified lines
+//     unique to avoid incorrect matches.
+//   * Use {{}} for regular expressions.
+// CHECK-FIXES: {{^}}void awesome_f();{{$}}
+
+// FIXME: Add something that doesn't trigger the check here.
+// void awesome_f2();


### PR DESCRIPTION
This PR sets up the Kokkos clang-tidy module and also adds a check for detection of the use of implicit this in a lambda passed to `Kokkos::parallel_*`. 