### PR TITLE
Kokkos ensure kokkos function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ autoconf/autom4te.cache
 /CMakeSettings.json
 # CLion project configuration
 /.idea
+/.cache
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).

--- a/clang-tools-extra/clang-tidy/kokkos/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/kokkos/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS support)
 
 add_clang_library(clangTidyKokkosModule
+  EnsureKokkosFunctionCheck.cpp
   ImplicitThisCaptureCheck.cpp
   KokkosMatchers.cpp
   KokkosTidyModule.cpp

--- a/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
@@ -1,0 +1,103 @@
+//===--- EnsureKokkosFunctionCheck.cpp - clang-tidy -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "EnsureKokkosFunctionCheck.h"
+#include "KokkosMatchers.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace {
+
+using namespace clang;
+AST_MATCHER_P(Decl, matchesAttr, std::string, RegExp) {
+  assert(!RegExp.empty());
+  llvm::Regex Re(RegExp);
+  for (auto const *Attr : Node.attrs()) {
+    if (auto const *Anna = dyn_cast<AnnotateAttr>(Attr)) {
+      if (Re.match(Anna->getAnnotation())) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+std::string KF_Regex = "KOKKOS_.*FUNCTION";
+
+auto notKFunc = functionDecl(unless(matchesAttr(KF_Regex)),
+                             unless(isExpansionInSystemHeader()));
+auto notKCalls = callExpr(callee(notKFunc)).bind("CE");
+
+CallExpr const *checkLambdaBody(CXXRecordDecl const *Lambda) {
+  assert(Lambda->isLambda());
+
+  if (auto const *FD = Lambda->getLambdaCallOperator()) {
+    auto BadCalls = match(functionDecl(forEachDescendant(notKCalls)), *FD,
+                          FD->getASTContext());
+
+    if (!BadCalls.empty()) {
+      return selectFirst<CallExpr>("CE", BadCalls);
+    }
+  }
+
+  return nullptr;
+}
+
+} // namespace
+
+namespace clang {
+namespace tidy {
+namespace kokkos {
+
+void EnsureKokkosFunctionCheck::registerMatchers(MatchFinder *Finder) {
+
+  std::string KF_Regex = "KOKKOS_.*FUNCTION";
+
+  auto notKFunc = functionDecl(unless(matchesAttr(KF_Regex)),
+                               unless(isExpansionInSystemHeader()));
+  auto notKCalls = callExpr(callee(notKFunc)).bind("CE");
+
+  Finder->addMatcher(
+      functionDecl(matchesAttr(KF_Regex), forEachDescendant(notKCalls))
+          .bind("ParentFD"),
+      this);
+
+  auto Lambda = expr(hasType(cxxRecordDecl(isLambda()).bind("Lambda")));
+  Finder->addMatcher(callExpr(isKokkosParallelCall(), hasAnyArgument(Lambda)),
+                     this);
+}
+
+void EnsureKokkosFunctionCheck::check(const MatchFinder::MatchResult &Result) {
+
+  auto const *ParentFD = Result.Nodes.getNodeAs<FunctionDecl>("ParentFD");
+  auto const *CE = Result.Nodes.getNodeAs<CallExpr>("CE");
+  auto const *Lambda = Result.Nodes.getNodeAs<CXXRecordDecl>("Lambda");
+
+  if (ParentFD != nullptr) {
+    diag(CE->getDirectCallee()->getLocation(),
+         "function %0 is missing a KOKKOS_X_FUNCTION annotation")
+        << CE->getDirectCallee();
+    diag(CE->getBeginLoc(), "Called here in function %0.", DiagnosticIDs::Note)
+        << ParentFD;
+  }
+  if (Lambda != nullptr) {
+    auto BadCall = checkLambdaBody(Lambda);
+    if (BadCall) {
+      diag(BadCall->getBeginLoc(), "Function %0 called in a lambda was missing "
+                                   "KOKKOS_X_FUNCTION annotation.")
+          << BadCall->getDirectCallee();
+      diag(Lambda->getLocation(), "Lambda is here", DiagnosticIDs::Note);
+    }
+  }
+}
+
+} // namespace kokkos
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
@@ -21,13 +21,7 @@ namespace {
 std::string KF_Regex = "KOKKOS_.*FUNCTION"; // NOLINT
 
 auto notKFunc(std::string const &AllowedFuncRegex) {
-  auto AllowedFuncMatch = [AFR = AllowedFuncRegex] {
-    if (AFR.empty()) {
-      return unless(matchesName("a^")); // Never match anything
-    }
-    return unless(matchesName(AFR));
-  }();
-
+  auto AllowedFuncMatch = unless(matchesName(AllowedFuncRegex));
   return functionDecl(unless(matchesAttr(KF_Regex)),
                       unless(isExpansionInSystemHeader()), AllowedFuncMatch);
 }
@@ -134,7 +128,9 @@ EnsureKokkosFunctionCheck::EnsureKokkosFunctionCheck(StringRef Name,
                                                      ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context) {
   AllowIfExplicitHost = std::stoi(Options.get("AllowIfExplicitHost", "0"));
-  AllowedFunctionsRegex = Options.get("AllowedFunctionsRegex", "");
+  AllowedFunctionsRegex = Options.get("AllowedFunctionsRegex", "a^");
+  // This can't be empty because the regex ast matchers assert !empty
+  assert(!AllowedFunctionsRegex.empty());
 }
 
 void EnsureKokkosFunctionCheck::storeOptions(

--- a/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
@@ -1,5 +1,9 @@
 //===--- EnsureKokkosFunctionCheck.cpp - clang-tidy -----------------------===//
 //
+// Copyright 2020 National Technology & Engineering Solutions of Sandia,
+// LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -182,7 +186,7 @@ void EnsureKokkosFunctionCheck::check(const MatchFinder::MatchResult &Result) {
 
   if (Functor != nullptr) {
     auto const *CE = Result.Nodes.getNodeAs<CallExpr>("KokkosCE");
-    if (AllowIfExplicitHost != 0 && explicitDefaultHostExecutionSpace(CE)) {
+    if (AllowIfExplicitHost != 0 && explicitlyDefaultHostExecutionSpace(CE)) {
       return;
     }
 

--- a/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
@@ -150,7 +150,7 @@ void EnsureKokkosFunctionCheck::registerMatchers(MatchFinder *Finder) {
 
   // We have to be sure that we don't match functionDecls in systems headers,
   // because they might call our Functor, which if it is a lambda will not be
-  // marked with KOKKOS_FUNCITON
+  // marked with KOKKOS_FUNCTION
   Finder->addMatcher(functionDecl(matchesAttr(KF_Regex),
                                   unless(isExpansionInSystemHeader()),
                                   forEachDescendant(notKCalls))
@@ -207,9 +207,13 @@ void EnsureKokkosFunctionCheck::check(const MatchFinder::MatchResult &Result) {
           continue;
         }
 
-        diag(CalledMethod->getBeginLoc(), "Member Function of %0, requires a "
-                                          "KOKKOS_X_FUNCTION annotation.")
+        diag(CE->getBeginLoc(),
+             "Called a member function of %0 that requires a "
+             "KOKKOS_X_FUNCTION annotation.")
             << CalledMethod->getParent();
+        diag(CalledMethod->getBeginLoc(),
+             "Member Function %0 of %1 was delcared here", DiagnosticIDs::Note)
+            << CalledMethod << CalledMethod->getParent();
       }
     }
   }

--- a/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.cpp
@@ -15,30 +15,25 @@ using namespace clang::ast_matchers;
 
 namespace {
 
-using namespace clang;
-AST_MATCHER_P(Decl, matchesAttr, std::string, RegExp) {
-  assert(!RegExp.empty());
-  llvm::Regex Re(RegExp);
-  for (auto const *Attr : Node.attrs()) {
-    if (auto const *Anna = dyn_cast<AnnotateAttr>(Attr)) {
-      if (Re.match(Anna->getAnnotation())) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 std::string KF_Regex = "KOKKOS_.*FUNCTION";
 
-auto notKFunc = functionDecl(unless(matchesAttr(KF_Regex)),
-                             unless(isExpansionInSystemHeader()));
-auto notKCalls = callExpr(callee(notKFunc)).bind("CE");
-
-CallExpr const *checkLambdaBody(CXXRecordDecl const *Lambda) {
+CallExpr const *checkLambdaBody(CXXRecordDecl const *Lambda,
+                                std::string const &AllowedFuncRegex) {
   assert(Lambda->isLambda());
 
   if (auto const *FD = Lambda->getLambdaCallOperator()) {
+    auto AllowedFuncMatch = [AFR = AllowedFuncRegex] {
+      if (AFR.empty()) {
+        return unless(matchesName("a^")); // Never match anything
+      }
+      return unless(matchesName(AFR));
+    }();
+    auto notKFunc =
+        functionDecl(unless(matchesAttr(KF_Regex)),
+                     unless(isExpansionInSystemHeader()), AllowedFuncMatch);
+
+    auto notKCalls = callExpr(callee(notKFunc)).bind("CE");
+
     auto BadCalls = match(functionDecl(forEachDescendant(notKCalls)), *FD,
                           FD->getASTContext());
 
@@ -56,22 +51,47 @@ namespace clang {
 namespace tidy {
 namespace kokkos {
 
+EnsureKokkosFunctionCheck::EnsureKokkosFunctionCheck(StringRef Name,
+                                                     ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context) {
+  CheckIfExplicitHost = std::stoi(Options.get("CheckIfExplicitHost", "0"));
+  AllowedFunctionsRegex = Options.get("AllowedFunctionsRegex", "");
+}
+
+void EnsureKokkosFunctionCheck::storeOptions(
+    ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "AllowedFunctionsRegex", AllowedFunctionsRegex);
+  Options.store(Opts, "CheckIfExplicitHost",
+                std::to_string(CheckIfExplicitHost));
+}
+
 void EnsureKokkosFunctionCheck::registerMatchers(MatchFinder *Finder) {
+  auto AllowedFuncMatch = [AFR = AllowedFunctionsRegex] {
+    if (AFR.empty()) {
+      return unless(matchesName("a^")); // Never match anything
+    }
+    return unless(matchesName(AFR));
+  }();
 
-  std::string KF_Regex = "KOKKOS_.*FUNCTION";
+  auto notKFunc =
+      functionDecl(unless(matchesAttr(KF_Regex)),
+                   unless(isExpansionInSystemHeader()), AllowedFuncMatch);
 
-  auto notKFunc = functionDecl(unless(matchesAttr(KF_Regex)),
-                               unless(isExpansionInSystemHeader()));
   auto notKCalls = callExpr(callee(notKFunc)).bind("CE");
 
-  Finder->addMatcher(
-      functionDecl(matchesAttr(KF_Regex), forEachDescendant(notKCalls))
-          .bind("ParentFD"),
-      this);
+  // We have to be sure that we don't match functionDecls in systems headers,
+  // because they might call our Functor, which if it is a lambda will not be
+  // marked with KOKKOS_FUNCITON
+  Finder->addMatcher(functionDecl(matchesAttr(KF_Regex),
+                                  unless(isExpansionInSystemHeader()),
+                                  forEachDescendant(notKCalls))
+                         .bind("ParentFD"),
+                     this);
 
   auto Lambda = expr(hasType(cxxRecordDecl(isLambda()).bind("Lambda")));
-  Finder->addMatcher(callExpr(isKokkosParallelCall(), hasAnyArgument(Lambda)),
-                     this);
+  Finder->addMatcher(
+      callExpr(isKokkosParallelCall(), hasAnyArgument(Lambda)).bind("KokkosCE"),
+      this);
 }
 
 void EnsureKokkosFunctionCheck::check(const MatchFinder::MatchResult &Result) {
@@ -81,19 +101,22 @@ void EnsureKokkosFunctionCheck::check(const MatchFinder::MatchResult &Result) {
   auto const *Lambda = Result.Nodes.getNodeAs<CXXRecordDecl>("Lambda");
 
   if (ParentFD != nullptr) {
-    diag(CE->getDirectCallee()->getLocation(),
-         "function %0 is missing a KOKKOS_X_FUNCTION annotation")
+    diag(CE->getBeginLoc(),
+         "function %0 called in %1 is missing a KOKKOS_X_FUNCTION annotation")
+        << CE->getDirectCallee() << ParentFD;
+    diag(CE->getDirectCallee()->getLocation(), "Function %0 declared here",
+         DiagnosticIDs::Note)
         << CE->getDirectCallee();
-    diag(CE->getBeginLoc(), "Called here in function %0.", DiagnosticIDs::Note)
-        << ParentFD;
   }
   if (Lambda != nullptr) {
-    auto BadCall = checkLambdaBody(Lambda);
+    auto const* CE = Result.Nodes.getNodeAs<CallExpr>("KokkosCE");
+    if(explicitlyUsingHostExecutionSpace(CE, "Hi")){
+    }
+    auto const *BadCall = checkLambdaBody(Lambda, AllowedFunctionsRegex);
     if (BadCall) {
       diag(BadCall->getBeginLoc(), "Function %0 called in a lambda was missing "
                                    "KOKKOS_X_FUNCTION annotation.")
           << BadCall->getDirectCallee();
-      diag(Lambda->getLocation(), "Lambda is here", DiagnosticIDs::Note);
     }
   }
 }

--- a/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.h
+++ b/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.h
@@ -1,0 +1,35 @@
+//===--- EnsureKokkosFunctionCheck.h - clang-tidy ---------------*- C++ -*-===//
+//
+// Copyright 2020 National Technology & Engineering Solutions of Sandia,
+// LLC (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_KOKKOS_ENSUREKOKKOSFUNCTIONCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_KOKKOS_ENSUREKOKKOSFUNCTIONCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace kokkos {
+
+/// Check that ensures user provided functions were properly annotated
+class EnsureKokkosFunctionCheck : public ClangTidyCheck {
+public:
+  EnsureKokkosFunctionCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace kokkos
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_KOKKOS_ENSUREKOKKOSFUNCTIONCHECK_H

--- a/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.h
+++ b/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.h
@@ -29,7 +29,7 @@ public:
 
 private:
   std::string AllowedFunctionsRegex;
-  int CheckIfExplicitHost;
+  int AllowIfExplicitHost;
 };
 
 } // namespace kokkos

--- a/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.h
+++ b/clang-tools-extra/clang-tidy/kokkos/EnsureKokkosFunctionCheck.h
@@ -22,10 +22,14 @@ namespace kokkos {
 /// Check that ensures user provided functions were properly annotated
 class EnsureKokkosFunctionCheck : public ClangTidyCheck {
 public:
-  EnsureKokkosFunctionCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  EnsureKokkosFunctionCheck(StringRef Name, ClangTidyContext *Context);
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+
+private:
+  std::string AllowedFunctionsRegex;
+  int CheckIfExplicitHost;
 };
 
 } // namespace kokkos

--- a/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.cpp
@@ -68,7 +68,7 @@ void ImplicitThisCaptureCheck::check(const MatchFinder::MatchResult &Result) {
   auto const *CE = Result.Nodes.getNodeAs<CallExpr>("x");
 
   if (AllowIfExplicitHost != 0) {
-    if (explicitlyDefaultHostExecutionSpace(CE)) {
+    if (explicitDefaultHostExecutionSpace(CE)) {
       return;
     }
   }

--- a/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.cpp
@@ -45,8 +45,7 @@ ImplicitThisCaptureCheck::ImplicitThisCaptureCheck(StringRef Name,
   AllowIfExplicitHost = std::stoi(Options.get("AllowIfExplicitHost", "0"));
 }
 
-void ImplicitThisCaptureCheck::storeOptions(
-    ClangTidyOptions::OptionMap &Opts) {
+void ImplicitThisCaptureCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "AllowIfExplicitHost",
                 std::to_string(AllowIfExplicitHost));
 }
@@ -68,7 +67,7 @@ void ImplicitThisCaptureCheck::check(const MatchFinder::MatchResult &Result) {
   auto const *CE = Result.Nodes.getNodeAs<CallExpr>("x");
 
   if (AllowIfExplicitHost != 0) {
-    if (explicitDefaultHostExecutionSpace(CE)) {
+    if (explicitlyDefaultHostExecutionSpace(CE)) {
       return;
     }
   }

--- a/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.cpp
@@ -42,15 +42,13 @@ llvm::Optional<SourceLocation> capturesThis(CXXRecordDecl const *CRD) {
 ImplicitThisCaptureCheck::ImplicitThisCaptureCheck(StringRef Name,
                                                    ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context) {
-  CheckIfExplicitHost = std::stoi(Options.get("CheckIfExplicitHost", "0"));
-  HostTypeDefRegex =
-      Options.get("HostTypeDefRegex", "Kokkos::DefaultHostExecutionSpace");
+  AllowIfExplicitHost = std::stoi(Options.get("AllowIfExplicitHost", "0"));
 }
 
-void ImplicitThisCaptureCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
-  Options.store(Opts, "CheckIfExplicitHost",
-                std::to_string(CheckIfExplicitHost));
-  Options.store(Opts, "HostTypeDefRegex", HostTypeDefRegex);
+void ImplicitThisCaptureCheck::storeOptions(
+    ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "AllowIfExplicitHost",
+                std::to_string(AllowIfExplicitHost));
 }
 
 void ImplicitThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
@@ -69,8 +67,8 @@ void ImplicitThisCaptureCheck::registerMatchers(MatchFinder *Finder) {
 void ImplicitThisCaptureCheck::check(const MatchFinder::MatchResult &Result) {
   auto const *CE = Result.Nodes.getNodeAs<CallExpr>("x");
 
-  if (CheckIfExplicitHost) {
-    if (explicitlyUsingHostExecutionSpace(CE, HostTypeDefRegex)) {
+  if (AllowIfExplicitHost != 0) {
+    if (explicitlyDefaultHostExecutionSpace(CE)) {
       return;
     }
   }

--- a/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.h
+++ b/clang-tools-extra/clang-tidy/kokkos/ImplicitThisCaptureCheck.h
@@ -30,8 +30,7 @@ public:
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 private:
-  int CheckIfExplicitHost;
-  std::string HostTypeDefRegex;
+  int AllowIfExplicitHost;
 };
 
 } // namespace kokkos

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.cpp
@@ -16,19 +16,50 @@ namespace clang {
 namespace tidy {
 namespace kokkos {
 
-bool explicitlyUsingHostExecutionSpace(CallExpr const *CE,
-                                       std::string const &RegexString) {
+namespace {
+TypedefNameDecl const *getTypedefFromFirstTemplateArg(Expr const *E) {
+  if (E == nullptr) {
+    return nullptr;
+  }
+
+  auto const *TST = E->getType()->getAs<TemplateSpecializationType>();
+  if (TST == nullptr) {
+    return nullptr;
+  }
+  if (TST->getNumArgs() < 1) {
+    return nullptr;
+  }
+
+  auto const *TDT = TST->getArg(0).getAsType()->getAs<TypedefType>();
+  if (TDT == nullptr) {
+    return nullptr;
+  }
+
+  auto const *TDD = dyn_cast_or_null<TypedefNameDecl>(TDT->getDecl());
+  return TDD;
+}
+
+bool isMatchingAnnotation(Attr const *At, std::string const &target) {
+  if (auto const *Anna = dyn_cast<AnnotateAttr>(At)) {
+    if (Anna->getAnnotation() == target) {
+      return true;
+    }
+  }
+
+  return false;
+}
+} // namespace
+
+bool explicitDefaultHostExecutionSpace(CallExpr const *CE) {
   using namespace clang::ast_matchers;
   auto &Ctx = CE->getCalleeDecl()->getASTContext();
 
   // We will assume that any policy where the user might explicitly ask for the
   // host space inherits from Impl::PolicyTraits
-  auto FilterArgs =
-      hasAnyArgument(expr(hasType(classTemplateSpecializationDecl(
-                                      isDerivedFrom(cxxRecordDecl(
-                                          matchesName("Impl::PolicyTraits"))))
-                                      .bind("Policy")))
-                         .bind("expr"));
+  auto FilterArgs = hasAnyArgument(
+      expr(hasType(classTemplateSpecializationDecl(isDerivedFrom(
+               cxxRecordDecl(matchesName("Impl::PolicyTraits"))))))
+          .bind("expr"));
 
   // We have to jump through some hoops to find this, if we just looked at the
   // template type of the Policy constructor we lose the sugar and instead of
@@ -36,24 +67,13 @@ bool explicitlyUsingHostExecutionSpace(CallExpr const *CE,
   // to such as Kokkos::Serial, preventing us from figuring out if the user
   // actually asked for a host space specifically or just happens to have a
   // host space as the default space.
-  llvm::Regex Reg(RegexString);
   auto BNs = match(callExpr(FilterArgs), *CE, Ctx);
   for (auto &BN : BNs) {
-    if (auto const *E = BN.getNodeAs<Expr>("expr")) {
-      if (auto const *TST = E->getType()->getAs<TemplateSpecializationType>()) {
-        for (auto const &TA : TST->template_arguments()) {
-          if (auto const *TDT = TA.getAsType()->getAs<TypedefType>()) {
-            if (auto const *TDD = TDT->getDecl()) {
-              for (auto const *Attr : TDD->attrs()) {
-                if (auto const *Anna = dyn_cast<AnnotateAttr>(Attr)) {
-                  if (Anna->getAnnotation().equals(
-                          "DefaultHostExecutionSpace")) {
-                    return true;
-                  }
-                }
-              }
-            }
-          }
+    if (auto const *TDD =
+            getTypedefFromFirstTemplateArg(BN.getNodeAs<Expr>("expr"))) {
+      for (auto const *At : TDD->attrs()) {
+        if (isMatchingAnnotation(At, "DefaultHostExecutionSpace")) {
+          return true;
         }
       }
     }

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.cpp
@@ -50,7 +50,7 @@ bool isMatchingAnnotation(Attr const *At, std::string const &target) {
 }
 } // namespace
 
-bool explicitDefaultHostExecutionSpace(CallExpr const *CE) {
+bool explicitlyDefaultHostExecutionSpace(CallExpr const *CE) {
   using namespace clang::ast_matchers;
   auto &Ctx = CE->getCalleeDecl()->getASTContext();
 

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
@@ -33,8 +33,8 @@ AST_MATCHER(CallExpr, isKokkosParallelCall) {
   if (auto const *FD = Node.getDirectCallee()) {
     std::string Name = FD->getQualifiedNameAsString();
     StringRef SR(Name);
-    if (SR.startswith("Kokkos::parallel_") ||
-        SR.startswith("::Kokkos::parallel_")) {
+    if (SR.startswith("::Kokkos::parallel_") ||
+        SR.startswith("Kokkos::parallel_")) {
       return true;
     }
   }
@@ -57,7 +57,6 @@ AST_MATCHER_P(Decl, matchesAttr, std::string, RegExp) {
 }
 
 bool explicitDefaultHostExecutionSpace(CallExpr const *CE);
-
 } // namespace kokkos
 } // namespace tidy
 } // namespace clang

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
@@ -33,8 +33,8 @@ AST_MATCHER(CallExpr, isKokkosParallelCall) {
   if (auto const *FD = Node.getDirectCallee()) {
     std::string Name = FD->getQualifiedNameAsString();
     StringRef SR(Name);
-    if (SR.startswith("::Kokkos::parallel_") ||
-        SR.startswith("Kokkos::parallel_")) {
+    if (SR.startswith("Kokkos::parallel_") ||
+        SR.startswith("::Kokkos::parallel_")) {
       return true;
     }
   }

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
@@ -56,7 +56,7 @@ AST_MATCHER_P(Decl, matchesAttr, std::string, RegExp) {
   return false;
 }
 
-bool explicitlyDefaultHostExecutionSpace(CallExpr const *CE);
+bool explicitDefaultHostExecutionSpace(CallExpr const *CE);
 
 } // namespace kokkos
 } // namespace tidy

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
@@ -42,6 +42,20 @@ AST_MATCHER(CallExpr, isKokkosParallelCall) {
   return false;
 }
 
+AST_MATCHER_P(Decl, matchesAttr, std::string, RegExp) {
+  using namespace clang::ast_matchers;
+  assert(!RegExp.empty());
+  llvm::Regex Re(RegExp);
+  for (auto const *Attr : Node.attrs()) {
+    if (auto const *Anna = dyn_cast<AnnotateAttr>(Attr)) {
+      if (Re.match(Anna->getAnnotation())) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 bool explicitlyUsingHostExecutionSpace(CallExpr const *CE,
                                        std::string const &RegexString);
 

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
@@ -56,8 +56,7 @@ AST_MATCHER_P(Decl, matchesAttr, std::string, RegExp) {
   return false;
 }
 
-bool explicitlyUsingHostExecutionSpace(CallExpr const *CE,
-                                       std::string const &RegexString);
+bool explicitlyDefaultHostExecutionSpace(CallExpr const *CE);
 
 } // namespace kokkos
 } // namespace tidy

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
@@ -42,18 +42,10 @@ AST_MATCHER(CallExpr, isKokkosParallelCall) {
   return false;
 }
 
+bool matchesAnnotation(Decl const* D, std::string const& RegExp);
+
 AST_MATCHER_P(Decl, matchesAttr, std::string, RegExp) {
-  using namespace clang::ast_matchers;
-  assert(!RegExp.empty());
-  llvm::Regex Re(RegExp);
-  for (auto const *Attr : Node.attrs()) {
-    if (auto const *Anna = dyn_cast<AnnotateAttr>(Attr)) {
-      if (Re.match(Anna->getAnnotation())) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return matchesAnnotation(&Node, RegExp);
 }
 
 bool explicitlyDefaultHostExecutionSpace(CallExpr const *CE);

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosMatchers.h
@@ -56,7 +56,7 @@ AST_MATCHER_P(Decl, matchesAttr, std::string, RegExp) {
   return false;
 }
 
-bool explicitDefaultHostExecutionSpace(CallExpr const *CE);
+bool explicitlyDefaultHostExecutionSpace(CallExpr const *CE);
 } // namespace kokkos
 } // namespace tidy
 } // namespace clang

--- a/clang-tools-extra/clang-tidy/kokkos/KokkosTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/kokkos/KokkosTidyModule.cpp
@@ -13,6 +13,7 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
+#include "EnsureKokkosFunctionCheck.h"
 #include "ImplicitThisCaptureCheck.h"
 
 namespace clang {
@@ -22,6 +23,8 @@ namespace kokkos {
 class KokkosModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<EnsureKokkosFunctionCheck>(
+        "kokkos-ensure-kokkos-function");
     CheckFactories.registerCheck<ImplicitThisCaptureCheck>(
         "kokkos-implicit-this-capture");
   }

--- a/clang-tools-extra/clangd/Compiler.cpp
+++ b/clang-tools-extra/clangd/Compiler.cpp
@@ -83,6 +83,7 @@ buildCompilerInvocation(const ParseInputs &Inputs, clang::DiagnosticConsumer &D,
   CI->getPreprocessorOpts().PCHThroughHeader.clear();
   CI->getPreprocessorOpts().PCHWithHdrStop = false;
   CI->getPreprocessorOpts().PCHWithHdrStopCreate = false;
+  CI->getPreprocessorOpts().SetUpStaticAnalyzer = true;
 
   // Recovery expression currently only works for C++.
   if (CI->getLangOpts()->CPlusPlus) {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -120,6 +120,12 @@ New checks
   Flags use of the `C` standard library functions ``memset``, ``memcpy`` and
   ``memcmp`` and similar derivatives on non-trivial types.
 
+- New :doc:`kokkos-ensure-kokkos-function
+  <clang-tidy/checks/kokkos-ensure-kokkos-function>` check.
+
+  Check to ensure that a function called in a Kokkos parallel region is
+  annoated with ``KOKKOS_FUNCTION``
+
 - New :doc:`kokkos-implicit-this-capture
   <clang-tidy/checks/kokkos-implicit-this-capture>` check.
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -124,7 +124,7 @@ New checks
   <clang-tidy/checks/kokkos-ensure-kokkos-function>` check.
 
   Check to ensure that a function called in a Kokkos parallel region is
-  annoated with ``KOKKOS_FUNCTION``
+  annotated with ``KOKKOS_FUNCTION``
 
 - New :doc:`kokkos-implicit-this-capture
   <clang-tidy/checks/kokkos-implicit-this-capture>` check.

--- a/clang-tools-extra/docs/clang-tidy/checks/kokkos-ensure-kokkos-function.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/kokkos-ensure-kokkos-function.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - kokkos-ensure-kokkos-function
+
+kokkos-ensure-kokkos-function
+=============================
+
+FIXME: Describe what patterns does the check detect and why. Give examples.

--- a/clang-tools-extra/docs/clang-tidy/checks/kokkos-ensure-kokkos-function.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/kokkos-ensure-kokkos-function.rst
@@ -3,4 +3,5 @@
 kokkos-ensure-kokkos-function
 =============================
 
-FIXME: Describe what patterns does the check detect and why. Give examples.
+This check ensures that the user has annotated functions called by Kokkos with 
+one of the KOKKOS_FUNCTION style annotations.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -183,6 +183,7 @@ Clang-Tidy Checks
    `hicpp-multiway-paths-covered <hicpp-multiway-paths-covered.html>`_,
    `hicpp-no-assembler <hicpp-no-assembler.html>`_,
    `hicpp-signed-bitwise <hicpp-signed-bitwise.html>`_,
+   `kokkos-ensure-kokkos-function <kokkos-ensure-kokkos-function.html>`_,
    `kokkos-implicit-this-capture <kokkos-implicit-this-capture.html>`_,
    `linuxkernel-must-use-errs <linuxkernel-must-use-errs.html>`_,
    `llvm-header-guard <llvm-header-guard.html>`_,

--- a/clang-tools-extra/test/clang-tidy/checkers/Inputs/kokkos/Kokkos_Core_mock.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/Inputs/kokkos/Kokkos_Core_mock.h
@@ -85,14 +85,14 @@ namespace Impl {
 struct SomeHostExecutionSpace {};
 
 template <typename... Properties>
-struct PolicyTraits{};
+struct PolicyTraits {};
 } // namespace Impl
 
-using DefaultExecutionSpace = Impl::SomeHostExecutionSpace;
-using DefaultHostExecutionSpace = Impl::SomeHostExecutionSpace;
+using DefaultExecutionSpace [[clang::annotate("DefaultExecutionSpace")]] = Impl::SomeHostExecutionSpace;
+using DefaultHostExecutionSpace [[clang::annotate("DefaultHostExecutionSpace")]] = Impl::SomeHostExecutionSpace;
 
 template <class... Properties>
-class RangePolicy : public Impl::PolicyTraits<Properties...>{
+class RangePolicy : public Impl::PolicyTraits<Properties...> {
 public:
   RangePolicy(int, int) {}
 };

--- a/clang-tools-extra/test/clang-tidy/checkers/kokkos-ensure-kokkos-function.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/kokkos-ensure-kokkos-function.cpp
@@ -9,5 +9,4 @@ KOKKOS_FUNCTION void f(){foo();}
 // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: function 'foo' called in 'f' is missing a KOKKOS_X_FUNCTION annotation [kokkos-ensure-kokkos-function]
 
 
-// FIXME: Add something that doesn't trigger the check here.
 KOKKOS_FUNCTION void awesome_f2(){legal();}

--- a/clang-tools-extra/test/clang-tidy/checkers/kokkos-ensure-kokkos-function.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/kokkos-ensure-kokkos-function.cpp
@@ -1,0 +1,14 @@
+// RUN: %check_clang_tidy %s kokkos-ensure-kokkos-function %t
+
+// FIXME: Add something that triggers the check here.
+void f();
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'f' is insufficiently awesome [kokkos-ensure-kokkos-function]
+
+// FIXME: Verify the applied fix.
+//   * Make the CHECK patterns specific enough and try to make verified lines
+//     unique to avoid incorrect matches.
+//   * Use {{}} for regular expressions.
+// CHECK-FIXES: {{^}}void awesome_f();{{$}}
+
+// FIXME: Add something that doesn't trigger the check here.
+void awesome_f2();

--- a/clang-tools-extra/test/clang-tidy/checkers/kokkos-ensure-kokkos-function.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/kokkos-ensure-kokkos-function.cpp
@@ -1,14 +1,13 @@
-// RUN: %check_clang_tidy %s kokkos-ensure-kokkos-function %t
+// RUN: %check_clang_tidy %s kokkos-ensure-kokkos-function %t -- -header-filter=.* -system-headers -- -isystem %S/Inputs/kokkos/
 
-// FIXME: Add something that triggers the check here.
-void f();
-// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'f' is insufficiently awesome [kokkos-ensure-kokkos-function]
+#include "Kokkos_Core_mock.h"
 
-// FIXME: Verify the applied fix.
-//   * Make the CHECK patterns specific enough and try to make verified lines
-//     unique to avoid incorrect matches.
-//   * Use {{}} for regular expressions.
-// CHECK-FIXES: {{^}}void awesome_f();{{$}}
+KOKKOS_FUNCTION void legal(){}
+
+void foo(){}
+KOKKOS_FUNCTION void f(){foo();}
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: function 'foo' called in 'f' is missing a KOKKOS_X_FUNCTION annotation [kokkos-ensure-kokkos-function]
+
 
 // FIXME: Add something that doesn't trigger the check here.
-void awesome_f2();
+KOKKOS_FUNCTION void awesome_f2(){legal();}

--- a/clang-tools-extra/test/clang-tidy/checkers/kokkos-implicit-this-capture-exceptions.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/kokkos-implicit-this-capture-exceptions.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s kokkos-implicit-this-capture %t -- -config="{CheckOptions: [{key: kokkos-implicit-this-capture.CheckIfExplicitHost, value: 1}]}" -header-filter=.* -system-headers -- -isystem %S/Inputs/kokkos/
+// RUN: %check_clang_tidy %s kokkos-implicit-this-capture %t -- -config="{CheckOptions: [{key: kokkos-implicit-this-capture.AllowIfExplicitHost, value: 1}]}" -header-filter=.* -system-headers -- -isystem %S/Inputs/kokkos/
 
 #include "Kokkos_Core_mock.h"
 


### PR DESCRIPTION
The ensure-kokkos-function check will catch the following issues in users code:
```c++
void fooOOPS(int i){printf("%i",i);}

KOKKOS_FUNCTION void bar(int i){
   fooOOPS(i); // Should warn
}

void bar2(){
  Kokkos::parallel_for(15, KOKKOS_LAMBDA(int i){
      fooOOPS(i); // Should warn
      });
}
```
In both of these examples it is possible that the code will compile and run acceptably in certain circumstances, default execution space is OpenMP or other host, but will fail when compiled for the cuda backend.  The goal is to help users who mainly develop on host but then need to run on devices. 

We have provided a way to opt out of the check when the default host execution space is used.
```cpp
void fooOOPS(int i){printf("%i",i);}

// We require the annotation to turn off the warning below, 
// this annotation is added to Kokkos::DefaultHostExecutionSpace automatically in develop
using MyHostSpace
#if defined(__clang_analyzer__)
 [[clang::annotate("DefaultHostExectutionSpace")]] 
#endif
= Kokkos::Serial;

void bar2(){
  Kokkos::parallel_for(Kokkos::RangePolicy<MyHostSpace>(15), KOKKOS_LAMBDA(int i){
      fooOOPS(i); // This warning can be turned off, but is on by default.  
      });
}
```

There are a few minor corner cases that might trigger the warning or will be false negatives, but I deemed the work to catch them to be excessive without complaints from users
```c++
template<typename F>
KOKKOS_FUNCTION void runF(F f){
  f(); // Won't warn if this is a lambda even if it breaks on cuda
}

void bar(){
  auto func = []{};
  Kokkos::parallel_for(15, KOKKOS_LAMBDA(int i){
      runF(func); // Won't warn
    });
}
```

The reason this won't warn is because we have to allow the following
```c++
KOKKOS_FUNCTION void foo(){
  []{}(); // Can't warn here, detecting that lambda::operator() is local to foo is not trivial. 
}
```
I'm sure that with enough users there will be other issues, but I think it's robust enough for release. 
